### PR TITLE
Fix queue jump and null checks

### DIFF
--- a/src/core/models/player.ts
+++ b/src/core/models/player.ts
@@ -209,10 +209,11 @@ export class Player implements AbstractPlayer{
     }
 
     public async jump(position: number): Promise<QueueItem> {
-        const target = this.queue[position - 1];
-        this.queue = this.queue
-            .splice(0, position - 1)
-            .concat(this.queue.splice(position, this.queue.length - 1));
+        const index = position - 1;
+        if (index < 0 || index >= this.queue.length) {
+            throw new Error('Invalid position');
+        }
+        const [target] = this.queue.splice(index, 1);
         this.queue.unshift(target);
         await this.play();
         return target;

--- a/src/core/services/noti/InteractionNotification.ts
+++ b/src/core/services/noti/InteractionNotification.ts
@@ -22,7 +22,7 @@ export class InteractionNotification implements INotification
     }
 
     public async showNowPlaying(player: Player, userInteraction: any, queueItem: QueueItem) {
-        if (userInteraction === undefined || null) {
+        if (userInteraction === undefined || userInteraction === null) {
             console.log('wrong here =========')
             return;
         }

--- a/src/core/services/noti/notification.ts
+++ b/src/core/services/noti/notification.ts
@@ -5,7 +5,7 @@ import {QueueItem} from "@/core/models/abstract-player.model";
 
 export class NotificationService {
     public static async nowPlaying(player: Player, interaction: any) {
-        if (interaction === undefined || null) {
+        if (interaction === undefined || interaction === null) {
             console.log('wrong here =========')
             return;
         }


### PR DESCRIPTION
## Summary
- improve jump() logic in Player
- fix null checks when displaying now playing notifications

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6889c6cb59c08326a93566e1759a016c