### PR TITLE
refactor: introduce event bus and modular listeners

### DIFF
--- a/src/bot-application.ts
+++ b/src/bot-application.ts
@@ -7,7 +7,8 @@ import {botClient} from '@/bot-client';
 import {EventsRouter} from '@/features/audio-player/events.router';
 import {InteractionHandler} from "@/core/services/interaction.service";
 import {logger} from "@/core/utils/logger.util";
-import {players} from "@/core/constants/common.constant";
+import {initAudioPlayer} from '@/features/audio-player';
+import {initModeratingMessage} from '@/features/moderating-message';
 
 config();
 export class Bot {
@@ -38,6 +39,8 @@ export class Bot {
 
   private bootstrap() {
     EventsRouter();
+    initAudioPlayer();
+    initModeratingMessage();
     new InteractionHandler();
   }
 }

--- a/src/core/services/interaction.service.ts
+++ b/src/core/services/interaction.service.ts
@@ -4,10 +4,27 @@ import {ephemeralResponse} from "@/core/utils/common.util";
 import * as Constant from "@/core/constants/index.constant";
 import {BUTTON_AUDIO_PLAYER_MAP, SELECT_MENU_AUDIO_PLAYER_MAP} from "@/features/audio-player/constants/map.constant";
 import {MODERATING_MESSAGE_COMMAND_MAP} from "@/core/commands/moderating-message.command";
+import {eventBus} from '@/core/utils/event-bus.util';
 
 export class InteractionHandler {
 
     constructor() {
+        eventBus.on('interaction:received', async (interaction: any) => {
+            const handlers = [
+                { check: interaction.isCommand, handle: interactionCreateStream.emitInteractionSlashCommand },
+                { check: interaction.isSelectMenu, handle: interactionCreateStream.emitInteractionSelectMenu },
+                { check: interaction.isButton, handle: interactionCreateStream.emitInteractionButton },
+                { check: interaction.isAutocomplete, handle: interactionCreateStream.emitInteractionAutoComplete },
+            ];
+
+            for (const { check, handle } of handlers) {
+                if (check.call(interaction)) {
+                    handle.call(interactionCreateStream, interaction);
+                    break;
+                }
+            }
+        });
+
         this.executeButtonCommand();
         this.executeSlashCommand();
         this.executeSelectMenu();

--- a/src/core/utils/event-bus.util.ts
+++ b/src/core/utils/event-bus.util.ts
@@ -1,0 +1,5 @@
+import {EventEmitter} from 'events';
+
+class EventBus extends EventEmitter {}
+
+export const eventBus = new EventBus();

--- a/src/features/audio-player/events.router.ts
+++ b/src/features/audio-player/events.router.ts
@@ -1,42 +1,19 @@
 import {botClient} from '@/bot-client';
 import {Message} from 'discord.js';
-import MessageMusicController from '@/features/audio-player/cmd-message/play.msg';
-import {interactionCreateStream} from "@/core/services/others/interaction-create.service";
-import MessageRestrictController from "@/features/moderating-message/cmd-message/restrict.msg";
-import {players} from "@/core/constants/common.constant";
-import {logger} from "@/core/utils/logger.util";
+import {eventBus} from '@/core/utils/event-bus.util';
 
 export const EventsRouter = () => {
 
   botClient.on('messageCreate', (message: Message) => {
-    MessageMusicController.handleLink(message);
-    MessageRestrictController.restrict(message);
+    eventBus.emit('message:created', message);
   });
 
   botClient.on('voiceStateUpdate', (oldState, newState) => {
-    if (oldState.member?.id !== botClient.user?.id) return;
-
-    if (oldState.channelId && !newState.channelId) {
-      logger.info(`Bot was disconnected from voice channel | GuildId: ${oldState.guild.id}!`);
-      const player = players.get(oldState.guild.id);
-      if (player) player.leave();
-    }
+    eventBus.emit('voice:updated', oldState, newState);
   });
 
   botClient.on('interactionCreate', async (interaction: any) => {
-    const handlers = [
-      { check: interaction.isCommand, handle: interactionCreateStream.emitInteractionSlashCommand },
-      { check: interaction.isSelectMenu, handle: interactionCreateStream.emitInteractionSelectMenu },
-      { check: interaction.isButton, handle: interactionCreateStream.emitInteractionButton },
-      { check: interaction.isAutocomplete, handle: interactionCreateStream.emitInteractionAutoComplete },
-    ];
-
-    for (const { check, handle } of handlers) {
-      if (check.call(interaction)) {
-        handle.call(interactionCreateStream, interaction);
-        break;
-      }
-    }
+    eventBus.emit('interaction:received', interaction);
   });
 
 };

--- a/src/features/audio-player/index.ts
+++ b/src/features/audio-player/index.ts
@@ -1,0 +1,7 @@
+import {registerMessageMusicListener} from './listeners/message-music.listener';
+import {registerVoiceListener} from './listeners/voice.listener';
+
+export const initAudioPlayer = () => {
+  registerMessageMusicListener();
+  registerVoiceListener();
+};

--- a/src/features/audio-player/listeners/message-music.listener.ts
+++ b/src/features/audio-player/listeners/message-music.listener.ts
@@ -1,8 +1,9 @@
-import { Message } from 'discord.js';
-import { MusicAreas } from '@/core/mongodb/music-area.model';
+import {Message} from 'discord.js';
+import {eventBus} from '@/core/utils/event-bus.util';
+import {MusicAreas} from '@/core/mongodb/music-area.model';
 import * as Constant from '@/core/constants/index.constant';
-import { UrlService } from '@/core/services/music/url.service';
-import {logger} from "@/core/utils/logger.util";
+import {UrlService} from '@/core/services/music/url.service';
+import {logger} from '@/core/utils/logger.util';
 
 const handleYoutubeLink = async (msg: Message) => {
   const query = MusicAreas.where({ textChannelId: msg.channel.id });
@@ -48,6 +49,7 @@ const voiceCondition = async (
   }
   return true;
 };
-export default {
-  handleLink: handleYoutubeLink,
+
+export const registerMessageMusicListener = () => {
+  eventBus.on('message:created', handleYoutubeLink);
 };

--- a/src/features/audio-player/listeners/voice.listener.ts
+++ b/src/features/audio-player/listeners/voice.listener.ts
@@ -1,0 +1,18 @@
+import {eventBus} from '@/core/utils/event-bus.util';
+import {botClient} from '@/bot-client';
+import {players} from '@/core/constants/common.constant';
+import {logger} from '@/core/utils/logger.util';
+
+const handleVoiceUpdate = (oldState: any, newState: any) => {
+  if (oldState.member?.id !== botClient.user?.id) return;
+
+  if (oldState.channelId && !newState.channelId) {
+    logger.info(`Bot was disconnected from voice channel | GuildId: ${oldState.guild.id}!`);
+    const player = players.get(oldState.guild.id);
+    if (player) player.leave();
+  }
+};
+
+export const registerVoiceListener = () => {
+  eventBus.on('voice:updated', handleVoiceUpdate);
+};

--- a/src/features/moderating-message/index.ts
+++ b/src/features/moderating-message/index.ts
@@ -1,0 +1,5 @@
+import {registerMessageRestrictListener} from './listeners/restrict-message.listener';
+
+export const initModeratingMessage = () => {
+  registerMessageRestrictListener();
+};

--- a/src/features/moderating-message/listeners/restrict-message.listener.ts
+++ b/src/features/moderating-message/listeners/restrict-message.listener.ts
@@ -1,5 +1,6 @@
-import { Message } from 'discord.js';
-import { RestrictChannel } from '@/core/mongodb/restrict.model';
+import {Message} from 'discord.js';
+import {eventBus} from '@/core/utils/event-bus.util';
+import {RestrictChannel} from '@/core/mongodb/restrict.model';
 
 const restrict = async (msg: Message) => {
   const query = RestrictChannel.where({ guildId: msg.guildId });
@@ -25,26 +26,7 @@ const restrict = async (msg: Message) => {
     });
   }
 };
-export default {
-  restrict,
-};
 
-/**
- * test DB
- * "guildId": "325650252386271238",
- *   "guildName": "AKG",
- *   "restrictChannels": [
- *     {
- *       "channelId": "325650252386271238",
- *       "channelName": "xam-loz",
- *       "roleId": "1010780985245311028",
- *       "roleName": "Kenh Chat"
- *     },
- *     {
- *       "channelId": "878130330068996097",
- *       "channelName": "mu-sic-que",
- *       "roleId": "682233159215349773",
- *       "roleName": "Bot"
- *     }
- *   ]
- */
+export const registerMessageRestrictListener = () => {
+  eventBus.on('message:created', restrict);
+};


### PR DESCRIPTION
## Summary
- add event bus utility and refactor EventsRouter to emit high-level events
- move message and voice handlers into modular listeners for audio player and moderation features
- initialize feature listeners during bot bootstrap for pluggable features

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run eslint` *(fails: Strings must use singlequote; 50 problems)*

------
https://chatgpt.com/codex/tasks/task_e_6898625840948326bb5777eb469dd1c0