### PR TITLE
refactor: add repositories for mongo models

### DIFF
--- a/src/core/repositories/music-area.repository.ts
+++ b/src/core/repositories/music-area.repository.ts
@@ -1,0 +1,51 @@
+import { Model } from 'mongoose';
+import { MusicAreas } from '@/core/mongodb/music-area.model';
+
+export interface MusicAreaDocument {
+  guildId: string;
+  guildName: string;
+  textChannelId: string;
+}
+
+export class MusicAreaRepository {
+  constructor(private readonly model: Model<any> = MusicAreas) {}
+
+  async findByGuildId(guildId: string) {
+    try {
+      return await this.model.findOne({ guildId }).exec();
+    } catch (error) {
+      console.error('Cannot find at MusicAreaRepository.findByGuildId', error);
+      return null;
+    }
+  }
+
+  async findByTextChannelId(textChannelId: string) {
+    try {
+      return await this.model.findOne({ textChannelId }).exec();
+    } catch (error) {
+      console.error('Cannot find at MusicAreaRepository.findByTextChannelId', error);
+      return null;
+    }
+  }
+
+  async insert(doc: MusicAreaDocument) {
+    try {
+      return await this.model.collection.insertOne(doc);
+    } catch (error) {
+      console.error('Cannot insert at MusicAreaRepository.insert', error);
+      return null;
+    }
+  }
+
+  async updateTextChannelId(guildId: string, textChannelId: string) {
+    try {
+      return await this.model.collection.updateOne(
+        { guildId },
+        { $set: { textChannelId } },
+      );
+    } catch (error) {
+      console.error('Cannot update at MusicAreaRepository.updateTextChannelId', error);
+      return null;
+    }
+  }
+}

--- a/src/core/repositories/restrict-channel.repository.ts
+++ b/src/core/repositories/restrict-channel.repository.ts
@@ -1,0 +1,44 @@
+import { Model } from 'mongoose';
+import { RestrictChannel } from '@/core/mongodb/restrict.model';
+
+export interface RestrictChannelDocument {
+  guildId: string;
+  guildName: string;
+  restrictChannels: Array<{
+    channelId: string;
+    channelName: string;
+    roleId: string;
+    roleName: string;
+  }>;
+}
+
+export class RestrictChannelRepository {
+  constructor(private readonly model: Model<any> = RestrictChannel) {}
+
+  async findByGuildId(guildId: string) {
+    try {
+      return await this.model.findOne({ guildId }).exec();
+    } catch (error) {
+      console.error('Cannot find at RestrictChannelRepository.findByGuildId', error);
+      return null;
+    }
+  }
+
+  async insert(doc: RestrictChannelDocument) {
+    try {
+      return await this.model.collection.insertOne(doc);
+    } catch (error) {
+      console.error('Cannot insert at RestrictChannelRepository.insert', error);
+      return null;
+    }
+  }
+
+  async update(guildId: string, data: Partial<RestrictChannelDocument>) {
+    try {
+      return await this.model.collection.updateOne({ guildId }, { $set: data });
+    } catch (error) {
+      console.error('Cannot update at RestrictChannelRepository.update', error);
+      return null;
+    }
+  }
+}

--- a/src/core/services/player.service.ts
+++ b/src/core/services/player.service.ts
@@ -2,7 +2,7 @@ import {VoiceConnection, VoiceConnectionStatus,} from '@discordjs/voice';
 import {TextChannel} from 'discord.js';
 import {players} from '@/core/constants/common.constant';
 import {logger} from '@/core/utils/logger.util';
-import {MusicAreas} from '@/core/mongodb/music-area.model';
+import {MusicAreaRepository} from '@/core/repositories/music-area.repository';
 import {Messages} from '@/core/constants/messages.constant';
 import {botClient} from "@/bot-client";
 import {VoiceConnectionManager} from "@/core/services/connection-manager.service";
@@ -20,6 +20,7 @@ export class Player {
   constructor(
     voiceConnection: VoiceConnection,
     private guildId: string,
+    private readonly musicAreaRepository: MusicAreaRepository = new MusicAreaRepository(),
   ) {
     this.voiceConnectionManager = new VoiceConnectionManager(voiceConnection);
     this.audioManager = new AudioManager();
@@ -41,8 +42,7 @@ export class Player {
     if (!payload.nextSong?.song) return;
 
     try {
-      const query = MusicAreas.where({ guildId: guildId });
-      const musicAreaChannel = await query.findOne();
+      const musicAreaChannel = await this.musicAreaRepository.findByGuildId(guildId);
 
       if (musicAreaChannel === null || musicAreaChannel === undefined) {
         logger.warn('not found music area in this guild, at player.service.ts');

--- a/src/features/audio-player/listeners/message-music.listener.ts
+++ b/src/features/audio-player/listeners/message-music.listener.ts
@@ -1,13 +1,16 @@
 import {Message} from 'discord.js';
 import {eventBus} from '@/core/utils/event-bus.util';
-import {MusicAreas} from '@/core/mongodb/music-area.model';
+import {MusicAreaRepository} from '@/core/repositories/music-area.repository';
 import * as Constant from '@/core/constants/index.constant';
 import {UrlService} from '@/core/services/music/url.service';
 import {logger} from '@/core/utils/logger.util';
 
+const musicAreaRepository = new MusicAreaRepository();
+
 const handleYoutubeLink = async (msg: Message) => {
-  const query = MusicAreas.where({ textChannelId: msg.channel.id });
-  const musicAreaChannel = await query.findOne();
+  const musicAreaChannel = await musicAreaRepository.findByTextChannelId(
+    msg.channel.id,
+  );
 
   if (!(await voiceCondition(msg, musicAreaChannel))) return;
   const input = msg.content;

--- a/src/features/moderating-message/cmd-slash/restrict.command.ts
+++ b/src/features/moderating-message/cmd-slash/restrict.command.ts
@@ -1,5 +1,5 @@
 import * as Constant from '@/core/constants/index.constant';
-import { RestrictChannel } from '@/core/mongodb/restrict.model';
+import { RestrictChannelRepository } from '@/core/repositories/restrict-channel.repository';
 import { ISlashCommand } from '@/core/interfaces/command.interface';
 import { SlashCommandBuilder } from '@discordjs/builders';
 import { ChannelType } from 'discord-api-types/v9';
@@ -23,11 +23,12 @@ export const restrictCommand: ISlashCommand = {
     // await interaction.deferReply();
     // const selectedChannel = interaction.options;
     //
-    // const foundChannel = await RestrictChannel.findOne({
-    //   guildId: interaction.guildId,
-    // });
+    // const repository = new RestrictChannelRepository();
+    // const foundChannel = await repository.findByGuildId(
+    //   interaction.guildId,
+    // );
     // if (foundChannel === null || foundChannel === undefined) {
-    //   await RestrictChannel.collection.insertOne({
+    //   await repository.insert({
     //     guildId: interaction.guildId,
     //     guildName: interaction.member?.guild.name,
     //     restrictChannels: [],

--- a/src/features/moderating-message/cmd-slash/set-music-area.command.ts
+++ b/src/features/moderating-message/cmd-slash/set-music-area.command.ts
@@ -1,7 +1,7 @@
 import { Player } from '@/core/services/player.service';
 import * as Constant from '@/core/constants/index.constant';
 import { players } from '@/core/constants/index.constant';
-import { MusicAreas } from '@/core/mongodb/music-area.model';
+import { MusicAreaRepository } from '@/core/repositories/music-area.repository';
 import { ISlashCommand } from '@/core/interfaces/command.interface';
 import { SlashCommandBuilder } from '@discordjs/builders';
 
@@ -18,12 +18,12 @@ export const setMusicAreaCommand: ISlashCommand = {
       await interaction.followUp(Constant.Messages.joinVoiceChannel);
       return;
     }
-
-    const musicAreaChannel = await MusicAreas.findOne({
-      guildId: interaction.guildId,
-    });
+    const repository = new MusicAreaRepository();
+    const musicAreaChannel = await repository.findByGuildId(
+      interaction.guildId,
+    );
     if (musicAreaChannel === null || musicAreaChannel === undefined) {
-      await MusicAreas.collection.insertOne({
+      await repository.insert({
         guildId: interaction.guildId,
         guildName: interaction.member?.guild.name,
         textChannelId: interaction.channelId,
@@ -32,9 +32,9 @@ export const setMusicAreaCommand: ISlashCommand = {
         Constant.Messages.settingUpPaP(interaction.channelId),
       );
     } else {
-      await MusicAreas.collection.updateOne(
-        { guildId: interaction.guildId },
-        { $set: { textChannelId: interaction.channelId } },
+      await repository.updateTextChannelId(
+        interaction.guildId,
+        interaction.channelId,
       );
       await interaction.followUp(
         Constant.Messages.settingUpPaP(interaction.channelId),

--- a/src/features/moderating-message/listeners/restrict-message.listener.ts
+++ b/src/features/moderating-message/listeners/restrict-message.listener.ts
@@ -1,10 +1,12 @@
 import {Message} from 'discord.js';
 import {eventBus} from '@/core/utils/event-bus.util';
-import {RestrictChannel} from '@/core/mongodb/restrict.model';
+import {RestrictChannelRepository} from '@/core/repositories/restrict-channel.repository';
+
+const restrictChannelRepository = new RestrictChannelRepository();
 
 const restrict = async (msg: Message) => {
-  const query = RestrictChannel.where({ guildId: msg.guildId });
-  const guild = await query.findOne();
+  if (!msg.guildId) return;
+  const guild = await restrictChannelRepository.findByGuildId(msg.guildId);
   if (!guild) return;
   let selectedChannel: any;
   guild.restrictChannels.forEach((element: any) => {


### PR DESCRIPTION
## Summary
- add MusicAreaRepository and RestrictChannelRepository for MongoDB models
- refactor player service and listeners/commands to use repositories
- add error logging and try/catch blocks to repository methods

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run eslint` *(fails: Strings must use singlequote, etc.)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68986ef48db483269ed58a03e4877a1f