### PR TITLE
Ensure FFmpeg transcoder cleanup

### DIFF
--- a/src/core/utils/prism-media.util.ts
+++ b/src/core/utils/prism-media.util.ts
@@ -39,12 +39,17 @@ export const createFFmpegStream = (stream: any, seekTime: number) => {
   });
 
   const cleanup = () => {
+    s16le.unpipe(encoder);
+    s16le.destroy();
+    transcoder.process?.kill();
     transcoder.destroy();
     stream.destroy?.();
   };
 
   encoder.once('close', cleanup);
   encoder.once('end', cleanup);
+  encoder.once('error', cleanup);
+  transcoder.once('close', cleanup);
 
   s16le.pipe(encoder);
   return encoder; // Return seeked stream


### PR DESCRIPTION
## Summary
- Ensure s16le and FFmpeg transcoder are properly cleaned up
- Listen for encoder errors and transcoder closes to trigger cleanup

## Testing
- `npm run eslint`
- `npm run build`
- `npm run prettier:check`


------
https://chatgpt.com/codex/tasks/task_e_6899bbea4484832683762d777abe60cf