### PR TITLE
Clear seeked stream after stop and seek

### DIFF
--- a/src/core/services/audio-player/queue-manager.service.ts
+++ b/src/core/services/audio-player/queue-manager.service.ts
@@ -88,6 +88,7 @@ export class QueueManager {
     this.audioManager.stop();
     if (this._currentSeekedStream) {
       this._currentSeekedStream.emit('close');
+      this._currentSeekedStream = null;
     }
   }
 
@@ -103,7 +104,10 @@ export class QueueManager {
       this._currentSong.song.platform === Platform.SPOTIFY
     )
       return;
-    if (this._currentSeekedStream) this._currentSeekedStream.emit('close');
+    if (this._currentSeekedStream) {
+      this._currentSeekedStream.emit('close');
+      this._currentSeekedStream = null;
+    }
 
     const songType = classifyUrl(this._currentSong.song.url);
     const sourceStream = new StreamClassifier(songType);
@@ -112,6 +116,9 @@ export class QueueManager {
     );
     const seekedStream = createFFmpegStream(audioResource, second);
     this._currentSeekedStream = seekedStream;
+    seekedStream.once('close', () => {
+      this._currentSeekedStream = null;
+    });
 
     this.audioManager.play(createAudioResource(seekedStream));
   }


### PR DESCRIPTION
## Summary
- reset internal seeked stream reference when stopping playback
- clean up seeked stream before seeking and clear reference once closed

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run eslint`
- `npm run prettier:check`


------
https://chatgpt.com/codex/tasks/task_e_6899bbca02688326a5e0b3d708248122