### PR TITLE
Clear current audio resource on stop

### DIFF
--- a/src/core/services/audio-player/audio-manager.service.ts
+++ b/src/core/services/audio-player/audio-manager.service.ts
@@ -54,6 +54,8 @@ export class AudioManager implements IAudioManager {
   }
 
   stop() {
+    this._currentResource?.playStream.destroy();
+    this._currentResource = null;
     this._audioPlayer.stop();
   }
 


### PR DESCRIPTION
## Summary
- Destroy current play stream and clear current resource before stopping audio player

## Testing
- `npm run build`
- `npm run eslint`


------
https://chatgpt.com/codex/tasks/task_e_6899bbb174e483268265f91cffacbd40