### PR TITLE
feat: set up vitest testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "prettier:check": "prettier --list-different 'src/**/*.{js,ts,tsx,scss}'",
     "eslint": "eslint src",
     "go": "npm run build && npm run start",
-    "test": "node --test -r ts-node/register"
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "license": "MIT",
   "dependencies": {
@@ -52,7 +53,10 @@
     "prettier": "^3.2.5",
     "ts-node": "^10.9.1",
     "tsconfig-paths": "^4.1.0",
-    "typescript": "^4.9.4"
+    "typescript": "^4.9.4",
+    "vitest": "^1.5.0",
+    "@vitest/coverage-v8": "^1.5.0",
+    "vite-tsconfig-paths": "^4.2.1"
   },
   "_moduleAliases": {
     "@": "dist"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -36,6 +36,7 @@
         "./*"
       ],
     },
+    "types": ["vitest/globals"],
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
     // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+import tsconfigPaths from 'vite-tsconfig-paths';
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+  test: {
+    environment: 'jsdom',
+    coverage: {
+      provider: 'v8'
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- add vitest and coverage dependencies
- configure vitest with ts path resolution and jsdom
- wire up vitest test scripts and types

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*


------
https://chatgpt.com/codex/tasks/task_e_6899b5a7d2a08326b235e58490fd74d8