### PR TITLE
test: add audio player service tests

### DIFF
--- a/src/core/services/audio-player/__test__/audio-manager.service.test.ts
+++ b/src/core/services/audio-player/__test__/audio-manager.service.test.ts
@@ -1,0 +1,71 @@
+import { AudioManager } from '../audio-manager.service';
+import { createAudioPlayer } from '@discordjs/voice';
+
+jest.mock('@discordjs/voice', () => ({
+  createAudioPlayer: jest.fn(),
+  AudioPlayerStatus: { Idle: 'idle' },
+}));
+
+jest.mock('@/core/utils/logger.util', () => ({
+  logger: { warn: jest.fn(), error: jest.fn() },
+}));
+
+describe('AudioManager', () => {
+  let mockPlayer: any;
+
+  beforeEach(() => {
+    mockPlayer = {
+      play: jest.fn(),
+      pause: jest.fn(),
+      unpause: jest.fn(),
+      stop: jest.fn(),
+      on: jest.fn(),
+    };
+    (createAudioPlayer as jest.Mock).mockReturnValue(mockPlayer);
+  });
+
+  it('plays audio resources', () => {
+    const manager = new AudioManager();
+    const first = { playStream: { destroy: jest.fn() } } as any;
+    const second = { playStream: { destroy: jest.fn() } } as any;
+
+    manager.play(first);
+    manager.play(second);
+
+    expect(first.playStream.destroy).toHaveBeenCalled();
+    expect(mockPlayer.play).toHaveBeenLastCalledWith(second);
+  });
+
+  it('pauses playback', () => {
+    const manager = new AudioManager();
+    manager.pause();
+    expect(mockPlayer.pause).toHaveBeenCalled();
+  });
+
+  it('resumes playback', () => {
+    const manager = new AudioManager();
+    manager.resume();
+    expect(mockPlayer.unpause).toHaveBeenCalled();
+  });
+
+  it('stops playback', () => {
+    const manager = new AudioManager();
+    manager.stop();
+    expect(mockPlayer.stop).toHaveBeenCalled();
+  });
+
+  it('emits error when play fails', (done) => {
+    mockPlayer.play.mockImplementation(() => {
+      throw new Error('fail');
+    });
+    const manager = new AudioManager();
+
+    manager.audioPlayerError.subscribe((value: boolean) => {
+      expect(value).toBe(true);
+      done();
+    });
+
+    const resource = { playStream: { destroy: jest.fn() } } as any;
+    manager.play(resource);
+  });
+});

--- a/src/core/services/audio-player/__test__/connection-manager.service.test.ts
+++ b/src/core/services/audio-player/__test__/connection-manager.service.test.ts
@@ -1,0 +1,9 @@
+import { VoiceConnectionManager } from '../connection-manager.service';
+
+describe('VoiceConnectionManager', () => {
+  it('returns the provided voice connection', () => {
+    const connection = {} as any;
+    const manager = new VoiceConnectionManager(connection);
+    expect(manager.voiceConnection).toBe(connection);
+  });
+});

--- a/src/core/services/audio-player/__test__/player.service.test.ts
+++ b/src/core/services/audio-player/__test__/player.service.test.ts
@@ -1,0 +1,69 @@
+const audioManagerMock = { player: {}, onIdle: jest.fn() };
+const queueManagerMock = { play: jest.fn(), stop: jest.fn(), currentSong: null };
+const deleteMock = jest.fn();
+const sendMock = jest.fn();
+const getMock = jest.fn().mockReturnValue({ send: sendMock });
+const musicAreaRepo = { findByGuildId: jest.fn() };
+const voiceConnectionMock = {
+  subscribe: jest.fn(),
+  state: { status: 'ready' },
+  destroy: jest.fn(),
+};
+
+jest.mock('@/core/services/audio-player/audio-manager.service', () => ({
+  AudioManager: jest.fn().mockImplementation(() => audioManagerMock),
+}));
+
+jest.mock('@/core/services/audio-player/queue-manager.service', () => ({
+  QueueManager: jest.fn().mockImplementation(() => queueManagerMock),
+}));
+
+jest.mock('@/core/constants/common.constant', () => ({
+  players: { delete: deleteMock },
+}));
+
+jest.mock('@/bot-client', () => ({
+  botClient: { channels: { cache: { get: getMock } } },
+}));
+
+jest.mock('@discordjs/voice', () => ({
+  VoiceConnectionStatus: { Destroyed: 'destroyed', Ready: 'ready' },
+}));
+
+const Messages = {
+  skippedSong: (payload: any) => `skip ${payload.title} - ${payload.requester}`,
+};
+jest.mock('@/core/constants/messages.constant', () => ({ Messages }));
+
+import { Player } from '../player.service';
+import { Messages as RealMessages } from '@/core/constants/messages.constant';
+
+describe('Player service', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('sends message on next song', async () => {
+    musicAreaRepo.findByGuildId.mockResolvedValue({ textChannelId: '123' });
+    const player = new Player(voiceConnectionMock as any, 'guild', musicAreaRepo as any);
+
+    await player.onNextSong({
+      nextSong: { song: { title: 'Title' }, requester: 'Req' },
+      guildId: 'guild',
+    });
+
+    expect(musicAreaRepo.findByGuildId).toHaveBeenCalledWith('guild');
+    expect(getMock).toHaveBeenCalledWith('123');
+    expect(sendMock).toHaveBeenCalledWith(
+      RealMessages.skippedSong({ title: 'Title', requester: 'Req' }),
+    );
+  });
+
+  it('cleans up on leave', () => {
+    const player = new Player(voiceConnectionMock as any, 'guild', musicAreaRepo as any);
+    player.leave();
+    expect(voiceConnectionMock.destroy).toHaveBeenCalled();
+    expect(queueManagerMock.stop).toHaveBeenCalled();
+    expect(deleteMock).toHaveBeenCalledWith('guild');
+  });
+});

--- a/src/core/services/audio-player/__test__/queue-manager.service.test.ts
+++ b/src/core/services/audio-player/__test__/queue-manager.service.test.ts
@@ -1,0 +1,122 @@
+import { QueueManager } from '../queue-manager.service';
+import { Platform } from '../../../types/song.type';
+import { QueueItem } from '../../../interfaces/player.interface';
+import { AudioPlayerStatus } from '@discordjs/voice';
+
+const classifyUrlMock = jest.fn().mockReturnValue('youtube');
+jest.mock('../../../utils/common.util', () => ({
+  classifyUrl: classifyUrlMock,
+}));
+
+const stream = { getStream: jest.fn(), getAudioResource: jest.fn() };
+const StreamClassifierMock = jest
+  .fn()
+  .mockImplementation(() => ({ stream }));
+jest.mock('../../../utils/stream-classifier.util', () => ({
+  StreamClassifier: StreamClassifierMock,
+}));
+
+const createFFmpegStreamMock = jest.fn();
+jest.mock('../../../utils/prism-media.util', () => ({
+  createFFmpegStream: createFFmpegStreamMock,
+}));
+
+jest.mock('@discordjs/voice', () => ({
+  AudioPlayerStatus: { Paused: 'paused' },
+  createAudioResource: jest.fn(() => 'seekResource'),
+}));
+
+describe('QueueManager', () => {
+  const audioManagerMock = {
+    player: { state: { status: '' } },
+    play: jest.fn(),
+    resume: jest.fn(),
+    stop: jest.fn(),
+    audioPlayerError: { subscribe: jest.fn() },
+  } as any;
+  let manager: QueueManager;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    manager = new QueueManager('guild', audioManagerMock);
+  });
+
+  it('plays song from queue', async () => {
+    const item: QueueItem = {
+      song: {
+        title: 't',
+        length: 100,
+        author: '',
+        thumbnail: '',
+        url: 'url',
+        platform: Platform.YOUTUBE,
+      },
+      requester: 'r',
+    };
+
+    (manager as any)._queue = [item];
+    jest
+      .spyOn(manager, 'getAudioResource')
+      .mockResolvedValue('resource' as any);
+
+    await manager.play();
+
+    expect(audioManagerMock.play).toHaveBeenCalledWith('resource');
+    expect(manager.currentSong).toEqual(item);
+  });
+
+  it('skips to next song', () => {
+    const playSpy = jest
+      .spyOn(manager, 'play')
+      .mockResolvedValue(undefined);
+    manager.skip();
+    expect(playSpy).toHaveBeenCalled();
+  });
+
+  it('seeks current song', async () => {
+    (manager as any)._currentSong = {
+      song: {
+        url: 'url',
+        length: 120,
+        platform: Platform.YOUTUBE,
+      },
+      requester: 'r',
+    };
+
+    stream.getStream.mockResolvedValue('audio');
+    createFFmpegStreamMock.mockReturnValue('ffmpeg');
+
+    await manager.seek(10);
+
+    expect(stream.getStream).toHaveBeenCalledWith('url');
+    expect(createFFmpegStreamMock).toHaveBeenCalledWith('audio', 10);
+    expect(audioManagerMock.play).toHaveBeenCalledWith('seekResource');
+  });
+
+  it('adds songs and resumes when paused', () => {
+    audioManagerMock.player.state.status = AudioPlayerStatus.Paused;
+    const songs: QueueItem[] = [
+      {
+        song: {
+          title: 't',
+          length: 100,
+          author: '',
+          thumbnail: '',
+          url: 'url',
+          platform: Platform.YOUTUBE,
+        },
+        requester: 'r',
+      },
+    ];
+
+    const playSpy = jest
+      .spyOn(manager, 'play')
+      .mockImplementation(async () => undefined);
+
+    manager.addSongs(songs);
+
+    expect(manager.queue).toHaveLength(1);
+    expect(playSpy).toHaveBeenCalled();
+    expect(audioManagerMock.resume).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for audio manager service covering playback controls and error handling
- verify voice connection manager getter
- test player service next-song messaging and leave cleanup
- check queue manager play, skip, seek, and addSongs behaviors

## Testing
- `npm run eslint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6899bc093f4483268f55c2f6c0c5b125