### PR TITLE
test: map @ alias for jest

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,8 +1,15 @@
 import type { JestConfigWithTsJest } from 'ts-jest';
+import { pathsToModuleNameMapper } from 'ts-jest';
 
 const config: JestConfigWithTsJest = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  moduleNameMapper: pathsToModuleNameMapper(
+    {
+      '@/*': ['src/*'],
+    },
+    { prefix: '<rootDir>/' }
+  ),
 };
 
 export default config;


### PR DESCRIPTION
## Summary
- map `@` alias to `src` in Jest config

## Testing
- `npm test` *(fails: cleanup on encoder close; cleanup on encoder end; ReferenceError classifyUrlMock before initialization)*

------
https://chatgpt.com/codex/tasks/task_e_689a11bacefc83268c58318bfeb388f6