### PR TITLE
chore: enable Jest globals for eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,6 +26,7 @@
     "no-case-declarations": 1
   },
   "env": {
-    "node": true
+    "node": true,
+    "jest": true
   }
 }


### PR DESCRIPTION
## Summary
- recognize Jest globals by enabling the jest environment in ESLint

## Testing
- `npm test 2>&1 | tail -n 20`
- `npm run eslint >/tmp/lint.log && tail -n 20 /tmp/lint.log`


------
https://chatgpt.com/codex/tasks/task_e_689a11d14e8083268b5aa6c03f39fce4